### PR TITLE
Update dotenv() to load .env.local file mentioned in readme.

### DIFF
--- a/api/agents.py
+++ b/api/agents.py
@@ -5,8 +5,8 @@ from pydantic import BaseModel
 from agents import Agent, Runner, WebSearchTool, ModelSettings
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
+# Load environment variables from .env.local file. If using .env, don't pass the '.env.local' arg.
+load_dotenv('.env.local')
 
 # Load OpenAI API key from environment
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
Issue: After following README instructions, the .env.local file exists but not a .env file. `load_dotenv()` was looking for a .env file. The developer needs to either 1) rename their `.env.local` file to `.env` or 2) pass in the '.env.local' string to `load_dotenv()`. 

I defaulted to #2 to align with current README instructions. Added comments so developers know their options.

After doing this, I was able to successfully start the python agent server.